### PR TITLE
Database duplicate return fix

### DIFF
--- a/EventListener/StringGeneratorListener.php
+++ b/EventListener/StringGeneratorListener.php
@@ -80,4 +80,4 @@ class StringGeneratorListener
 
     }
 
-} 
+}


### PR DESCRIPTION
This fix the return value when the ID generated is already in DB.

Test using 1 lenght and "123456789" alphabet, now dont work, return is null.

Also remove empty spaces.
