### PR TITLE
Fix AppBundle namespace issue

### DIFF
--- a/src/Vivait/StringGeneratorBundle/DependencyInjection/Compiler/GeneratorPass.php
+++ b/src/Vivait/StringGeneratorBundle/DependencyInjection/Compiler/GeneratorPass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\DependencyInjection\Compiler;
+namespace Vivait\StringGeneratorBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Vivait/StringGeneratorBundle/VivaitStringGeneratorBundle.php
+++ b/src/Vivait/StringGeneratorBundle/VivaitStringGeneratorBundle.php
@@ -2,7 +2,7 @@
 
 namespace Vivait\StringGeneratorBundle;
 
-use AppBundle\DependencyInjection\Compiler\GeneratorPass;
+use Vivait\StringGeneratorBundle\DependencyInjection\Compiler\GeneratorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 


### PR DESCRIPTION
Hello again,

Seems that 2.1 tag is broken. There are some issue with namespaces.

This are not detected by tests because they are not tested.

This will fix it.

Thank you