### PR TITLE
Symfony4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 php:
   - 7.1
+  - 7.2
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 cache:
   directories:
@@ -13,8 +11,6 @@ cache:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm
 
 before_install:
   - composer selfupdate
@@ -30,9 +26,6 @@ install:
   - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
   - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
   - composer require ramsey/uuid
-
-before_script:
-  - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4';" > php_version_tags.php
 
 script:
    - bin/phpspec run --format=pretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.5.3",
-        "doctrine/common": "~2.2",
-        "doctrine/orm": "~2.2",
-        "symfony/polyfill-php70": "^1.3",
-        "symfony/security": "^2.8|^3.0",
-        "symfony/options-resolver": "^2.8|^3.0",
+        "php": ">=7.1",
+        "doctrine/orm": "^2.6",
+        "symfony/security": "^3.3|^4.0",
+        "symfony/options-resolver": "^3.0|^4.0",
         "ircmaxell/random-lib": "~1.0",
-        "symfony/dependency-injection": "^2.7|^3.3",
-        "symfony/config": "^2.7|^3.3"
+        "symfony/dependency-injection": "^3.3|^4.0",
+        "symfony/config": "^3.3|^4.0"
     },
     "suggest": {
         "ramsey/uuid": "To use the UUID generator you should require this package"

--- a/src/Vivait/StringGeneratorBundle/EventListener/GeneratorListener.php
+++ b/src/Vivait/StringGeneratorBundle/EventListener/GeneratorListener.php
@@ -29,11 +29,6 @@ class GeneratorListener
     private $registry;
 
     /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
      * Registry has been made nullable as injecting it causes circular references. Instead, the container is injected
      * via a setter, and the registry is fetched from there instead.
      *
@@ -44,14 +39,6 @@ class GeneratorListener
     {
         $this->reader = $reader;
         $this->registry = $registry;
-    }
-
-    /**
-     * @param ContainerInterface $container
-     */
-    public function setContainer(ContainerInterface $container)
-    {
-        $this->container = $container;
     }
 
     /**
@@ -92,7 +79,7 @@ class GeneratorListener
     private function generateString($property, GeneratorAnnotation $annotation, $entity)
     {
         /** @var GeneratorInterface|ConfigurableGeneratorInterface $generator */
-        $generator = $this->getRegistry()->get($annotation->generator);
+        $generator = $this->registry->get($annotation->generator);
 
         $generator->setLength($annotation->length);
 
@@ -167,16 +154,5 @@ class GeneratorListener
     private function isMethod($class, $callback)
     {
         return method_exists($class, $callback) && is_callable([$class, $callback]);
-    }
-
-    /**
-     * @return Registry
-     */
-    private function getRegistry()
-    {
-        if($this->registry){
-            return $this->registry;
-        }
-        return $this->container->get('vivait_generator.registry');
     }
 }

--- a/src/Vivait/StringGeneratorBundle/Resources/config/services.yml
+++ b/src/Vivait/StringGeneratorBundle/Resources/config/services.yml
@@ -2,9 +2,10 @@ services:
     vivait_generator.generator.listener:
         class: Vivait\StringGeneratorBundle\EventListener\GeneratorListener
         public: false
-        arguments: ["@annotation_reader"]
-        calls:
-            - [setContainer, ["@service_container"]]
+        arguments:
+            - "@annotation_reader"
+            - "@vivait_generator.registry"
+
         tags:
             - { name: doctrine.event_listener, event: prePersist }
 


### PR DESCRIPTION
Hello guys!

We are updating our Symfony applications to last major version (4.x). The StringGeneratorBundle is an important package for us, that nowadays is not compatible with this version of Symfony.

I have changed a little things to made it compatible, and deprecate some versions of Symfony that maybe are a little old: like Symfony 2.7 or PHP 5.5 (unsupported). I push up the PHP version to 7.1 as a minium requeriment.

I think that if this changes are merged, they will need a new major version to avoid break old applications, but allow new to use this awesome package.

I am hearing any suggestions or calls to change.

Thank you so much!
Cheers.