### PR TITLE
Read private properties from parent class

### DIFF
--- a/src/Vivait/StringGeneratorBundle/EventListener/GeneratorListener.php
+++ b/src/Vivait/StringGeneratorBundle/EventListener/GeneratorListener.php
@@ -64,7 +64,13 @@ class GeneratorListener
         $meta = $em->getClassMetadata(get_class($entity));
         $this->repo = $em->getRepository($meta->getName());
 
-        $object = new \ReflectionObject($entity);
+        $currentObject = new \ReflectionObject($entity);
+        $properties = [];
+        do {
+            foreach ($currentObject->getProperties() as $property) {
+                $properties[] = $property;
+            }
+        } while (($currentObject = $currentObject->getParentClass()) && (false !== $currentObject));
 
         foreach ($object->getProperties() as $property) {
             foreach ($this->reader->getPropertyAnnotations($property) as $annotation) {

--- a/src/Vivait/StringGeneratorBundle/EventListener/GeneratorListener.php
+++ b/src/Vivait/StringGeneratorBundle/EventListener/GeneratorListener.php
@@ -72,7 +72,8 @@ class GeneratorListener
             }
         } while (($currentObject = $currentObject->getParentClass()) && (false !== $currentObject));
 
-        foreach ($object->getProperties() as $property) {
+        /** @var \ReflectionProperty[] $property */
+        foreach ($properties as $property) {
             foreach ($this->reader->getPropertyAnnotations($property) as $annotation) {
                 if ($annotation instanceof GeneratorAnnotation) {
 


### PR DESCRIPTION
Hello guys!

This PR fixes a little issue when you are working with a inheritance.

If you have a parent with private properties that use the annotation of the StringGeneratorBundle (Generate) it is ignored because it only uses the child properties. It should consider also the properties of parent.

The inheritance in Doctrine entities is not common, but there are a little use cases where use the ```Doctrine\ORM\Mapping\MappedSuperclass``` is absolutely needed and if you want maintain the properties private, before this patch, you couln't.

I hope that it helps!